### PR TITLE
Hide the logo mini as for the default Login

### DIFF
--- a/src/layouts/register/register.component.html
+++ b/src/layouts/register/register.component.html
@@ -1,7 +1,7 @@
 <body class="hold-transition register-page">
 <div class="register-box">
   <div class="register-logo">
-    <app-logo></app-logo>
+    <app-logo [hide]='"mini"'></app-logo>
   </div>
 
   <div class="register-box-body">


### PR DESCRIPTION
Hide the logo mini as for the default Login, just to be coherence with the Login default page.